### PR TITLE
Add native htable key-prefix deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ listen=tcp:127.0.0.1:HTTP_PORT
 
 loadmodule "xhttp.so"
 loadmodule "jsonrpcs.so"
+loadmodule "jansson.so"
 
 modparam("jsonrpcs", "transport", 1)
 
@@ -26,6 +27,33 @@ event_route[xhttp:request] {
     if ($hu =~ "^/RPC") {
         xlog("L_INFO", "jsonrpc dispatch [$hu] [$var(x)]");
         jsonrpc_dispatch();
+        return;
+    }
+    if ($var(x) == "/htable/delete-prefix") {
+        if ($rm != "POST") {
+            xhttp_reply("405", "Method Not Allowed", "application/json", "");
+            return;
+        }
+        $var(htable) = $null;
+        $var(key_prefix) = $null;
+        if (!jansson_get("htable", "$rb", "$var(htable)")
+                || !jansson_get("key_starts_with", "$rb", "$var(key_prefix)")
+                || $var(htable) == $null
+                || $var(key_prefix) == $null
+                || $var(htable) == ""
+                || $var(key_prefix) == "") {
+            xhttp_reply("400", "Bad Request", "application/json", "");
+            return;
+        }
+        if (!sht_has_name("$var(htable)", "sw", "$var(key_prefix)")) {
+            xhttp_reply("404", "Not Found", "application/json", "");
+            return;
+        }
+        if (!sht_rm_name("$var(htable)", "sw", "$var(key_prefix)")) {
+            xhttp_reply("500", "Internal Server Error", "application/json", "");
+            return;
+        }
+        xhttp_reply("204", "No Content", "", "");
         return;
     }
     xhttp_reply("404", "Not Found", "application/javascript", "{\"$var(y)\"}\n\r");
@@ -49,6 +77,12 @@ curl -X POST 'http://localhost:8080/v1/htable/mytable?action=flush'
 
 ```bash
 curl -X DELETE 'http://localhost:8080/v1/htable/mytable/mykey'
+```
+
+### htable delete by key prefix
+
+```bash
+curl -X DELETE 'http://localhost:8080/v1/htable/mytable?key_starts_with=mykey'
 ```
 
 ### htable get

--- a/internal/jsonrpcc/htable.go
+++ b/internal/jsonrpcc/htable.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/google/uuid"
@@ -354,6 +356,66 @@ func (a *API) htableDelete(ctx context.Context, tableName string, key string) er
 
 func (a *API) HTableDelete(ctx context.Context, tableName string, key string) error {
 	return a.htableDelete(ctx, tableName, key)
+}
+
+func (a *API) HTableDeleteKeyPrefix(ctx context.Context, tableName string, keyPrefix string) (bool, error) {
+	a.logger.Debug(
+		"htable delete key prefix",
+		zap.String("table name", tableName),
+		zap.String("key prefix", keyPrefix),
+	)
+	payload := struct {
+		TableName string `json:"htable"`
+		KeyPrefix string `json:"key_starts_with"`
+	}{
+		TableName: tableName,
+		KeyPrefix: keyPrefix,
+	}
+	body, err := json.Marshal(&payload)
+	if err != nil {
+		return false, fmt.Errorf("marshal htable prefix delete request: %w", err)
+	}
+	prefixDeleteURL, err := url.Parse(a.jsonrpcHTTPAddr)
+	if err != nil {
+		return false, fmt.Errorf("parse Kamailio server URL: %w", err)
+	}
+	prefixDeleteURL.Path = "/htable/delete-prefix"
+	prefixDeleteURL.RawPath = ""
+	prefixDeleteURL.RawQuery = ""
+	prefixDeleteURL.Fragment = ""
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		prefixDeleteURL.String(),
+		bytes.NewBuffer(body),
+	)
+	if err != nil {
+		return false, fmt.Errorf("create htable prefix delete request: %w", err)
+	}
+	req.Close = true
+	req.Header.Set("Content-Type", "application/json")
+	res, err := a.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("send htable prefix delete request: %w", err)
+	}
+	defer res.Body.Close()
+
+	switch res.StatusCode {
+	case http.StatusNoContent:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		responseBody, readErr := io.ReadAll(res.Body)
+		if readErr != nil {
+			return false, fmt.Errorf("read htable prefix delete response: %w", readErr)
+		}
+		return false, fmt.Errorf(
+			"unexpected htable prefix delete status code %d: %s",
+			res.StatusCode,
+			strings.TrimSpace(string(responseBody)),
+		)
+	}
 }
 
 func htableResultQueryKeyContains(ctx context.Context, h HTableDumpResult, value string) bool {

--- a/serverhttp/htable.go
+++ b/serverhttp/htable.go
@@ -127,6 +127,23 @@ func (h httpHandler) htableDeleteQuery(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode("missing table")
 		return
 	}
+	keyStartsWith := r.FormValue("key_starts_with")
+	if keyStartsWith != "" {
+		deleted, err := h.jsonrpcAPI.HTableDeleteKeyPrefix(ctx, table, keyStartsWith)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(err.Error())
+			return
+		}
+		if !deleted {
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode("no matching keys")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	keyContains := r.FormValue("key_contains")
 	valueContains := r.FormValue("value_contains")
 	if keyContains == "" && valueContains == "" {


### PR DESCRIPTION
#86e2jd7gn

## Why

The existing `key_contains` path dumps and decodes the entire htable, scans it in this service, and then issues an individual synchronous JSON-RPC delete for every returned entry. That is expensive for large tables and can cause cache invalidation to time out.

Kamailio supports native starts-with removal through `sht_rm_name`, which can perform the matching and deletion inside Kamailio without transferring the table or making repeated delete requests.

## What changed

- Add `DELETE /v1/htable/:table?key_starts_with=...`
- Send one request to `/htable/delete-prefix` on the existing `KAMAILIO_SERVER_URL` host
- Return `204` after a matching deletion and `404` when no key matches
- Leave the existing exact-delete and contains-delete paths unchanged
- Add the required Kamailio route and usage example to the existing README config section

No new environment variables are required.

## Kamailio requirement

The Kamailio xhttp configuration needs a `POST /htable/delete-prefix` route that reads `htable` and `key_starts_with`, checks for a match with `sht_has_name`, and removes matches with `sht_rm_name`.

## Testing

- `go test ./...`
- `go vet ./...`
